### PR TITLE
Add shortcuts for page navigation and history

### DIFF
--- a/apps/dragonfly_browser/lib/shortcuts/shortcuts.dart
+++ b/apps/dragonfly_browser/lib/shortcuts/shortcuts.dart
@@ -7,3 +7,7 @@ class SwitchTabIntent extends Intent {}
 class CloseTabIntent extends Intent {}
 
 class OpenHistoryIntent extends Intent {}
+
+class NavigationBackwardIntent extends Intent {}
+
+class NavigationForwardIntent extends Intent {}

--- a/apps/dragonfly_browser/lib/shortcuts/shortcuts.dart
+++ b/apps/dragonfly_browser/lib/shortcuts/shortcuts.dart
@@ -5,3 +5,5 @@ class NewTabIntent extends Intent {}
 class SwitchTabIntent extends Intent {}
 
 class CloseTabIntent extends Intent {}
+
+class OpenHistoryIntent extends Intent {}

--- a/apps/dragonfly_browser/lib/src/screens/browser_scaffold.dart
+++ b/apps/dragonfly_browser/lib/src/screens/browser_scaffold.dart
@@ -25,6 +25,8 @@ class LobbyScreen extends StatelessWidget {
               SwitchTabIntent(),
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyW):
               CloseTabIntent(),
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyH):
+              OpenHistoryIntent(),
         },
         child: Actions(
           actions: <Type, Action<Intent>>{
@@ -39,6 +41,10 @@ class LobbyScreen extends StatelessWidget {
             CloseTabIntent: CallbackAction<CloseTabIntent>(
               onInvoke: (CloseTabIntent intent) =>
                   context.read<BrowserCubit>().closeCurrentTab(),
+            ),
+            OpenHistoryIntent: CallbackAction<OpenHistoryIntent>(
+              onInvoke: (OpenHistoryIntent intent) =>
+                  showHistoryScreen(context),
             ),
           },
           child: Column(

--- a/apps/dragonfly_browser/lib/src/screens/browser_scaffold.dart
+++ b/apps/dragonfly_browser/lib/src/screens/browser_scaffold.dart
@@ -174,7 +174,7 @@ class BrowserTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Tooltip(
-      message: tab.currentPage!.getTitle(),
+      message: tab.currentPage?.getTitle() ?? "",
       waitDuration: const Duration(milliseconds: 300),
       child: ConstrainedBox(
         constraints: const BoxConstraints(maxWidth: 250, minWidth: 100),

--- a/apps/dragonfly_browser/lib/src/screens/browser_scaffold.dart
+++ b/apps/dragonfly_browser/lib/src/screens/browser_scaffold.dart
@@ -27,24 +27,32 @@ class LobbyScreen extends StatelessWidget {
               CloseTabIntent(),
           LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyH):
               OpenHistoryIntent(),
+          LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowLeft):
+              NavigationBackwardIntent(),
+          LogicalKeySet(LogicalKeyboardKey.alt, LogicalKeyboardKey.arrowRight):
+              NavigationForwardIntent(),
         },
         child: Actions(
           actions: <Type, Action<Intent>>{
             NewTabIntent: CallbackAction<NewTabIntent>(
-              onInvoke: (NewTabIntent intent) =>
-                  context.read<BrowserCubit>().openNewTab(),
+              onInvoke: (intent) => context.read<BrowserCubit>().openNewTab(),
             ),
             SwitchTabIntent: CallbackAction<SwitchTabIntent>(
-              onInvoke: (SwitchTabIntent intent) =>
+              onInvoke: (intent) =>
                   context.read<BrowserCubit>().switchToNextTab(),
             ),
             CloseTabIntent: CallbackAction<CloseTabIntent>(
-              onInvoke: (CloseTabIntent intent) =>
+              onInvoke: (intent) =>
                   context.read<BrowserCubit>().closeCurrentTab(),
             ),
             OpenHistoryIntent: CallbackAction<OpenHistoryIntent>(
-              onInvoke: (OpenHistoryIntent intent) =>
-                  showHistoryScreen(context),
+              onInvoke: (intent) => showHistoryScreen(context),
+            ),
+            NavigationBackwardIntent: CallbackAction<NavigationBackwardIntent>(
+              onInvoke: (intent) => context.read<BrowserCubit>().goBack(),
+            ),
+            NavigationForwardIntent: CallbackAction<NavigationForwardIntent>(
+              onInvoke: (intent) => context.read<BrowserCubit>().goForward(),
             ),
           },
           child: Column(


### PR DESCRIPTION
- `CTRL + H` -> open history
- `ALT + ARROW LEFT` -> navigate backward
- `ALT + ARROW RIGHT` -> navigate forward